### PR TITLE
Renamed the key in update payload

### DIFF
--- a/RELEASE_NOTES.txt
+++ b/RELEASE_NOTES.txt
@@ -5,6 +5,9 @@
 
 WolkGateway bridges communication between WolkAbout IoT platform and multiple devices connected to it.
 
+**Version 4.2.1**
+- [BUGFIX] - Fixed the message sent to update the gateway on initialization.
+
 **Version 4.2.0**
 - [IMPROVEMENT] - Automated .zip/.deb creation for release. This utilizes either local fs/Docker to create necessary things.
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,5 +1,5 @@
-wolkgateway (4.2.0) stable; urgency=medium
+wolkgateway (4.2.1) stable; urgency=medium
 
-  * Polished DEB release, automated DEB creation for both amd64/armv7l
-
- -- Wolkabout ELab <elab@wolkabout.com>  Wed, 27 May 2020 00:00:00 +0100
+ * Fixed the message sent to update the gateway on initialization.
+  
+ -- Wolkabout ELab <elab@wolkabout.com>  Mod, 7 Sep 2020 16:30:00 +0100

--- a/src/model/GatewayDevice.cpp
+++ b/src/model/GatewayDevice.cpp
@@ -21,7 +21,7 @@
 namespace wolkabout
 {
 const std::string GatewayDevice::FIRMWARE_UPDATE_TYPE = "DFU";
-const std::string GatewayDevice::SUBDEVICE_MANAGEMENT_PARAMETER = "subdeviceManagement";
+const std::string GatewayDevice::SUBDEVICE_MANAGEMENT_PARAMETER = "SUB_DEVICE_MANAGEMENT";
 const std::string GatewayDevice::GATEWAY_SUBDEVICE_MANAGEMENT = "GATEWAY";
 const std::string GatewayDevice::PLATFORM_SUBDEVICE_MANAGEMENT = "PLATFORM";
 const std::string GatewayDevice::FIRMWARE_UPDATE_PARAMETER = "supportsFirmwareUpdate";


### PR DESCRIPTION
This fixes the gateway update procedure that occurs when the gateway launches.
TypeParameter/SubdeviceManagement needed to be renamed to `SUB_DEVICE_MANAGEMENT`.

This now works with the value `GATEWAY`.

This is what the gateway sends:
```
2020-09-04 00:06:29[D]Sending message: {"actuators":[],"alarms":[],"configurations":[],"connectivityParameters":{},"firmwareUpdateParameters":{"supportsFileDownload":true,"supportsFileURL":false,"supportsFirmwareUpdate":false},"firmwareUpdateType":"","sensors":[],"typeParameters":{"SUB_DEVICE_MANAGEMENT":"GATEWAY"}}, to: d2p/update_gateway_request/g/astrihale-gateway
```

This is what it receives:
```
2020-09-04 00:06:30[D]GatewayInboundPlatformMessageHandler: Message received on channel: 'p2d/update_gateway_response/g/astrihale-gateway' : '{"result":"OK","description":null,"payload":null}'
```